### PR TITLE
chore: remove deprecated must_use on trait items

### DIFF
--- a/src/types/vertex.rs
+++ b/src/types/vertex.rs
@@ -12,26 +12,22 @@ pub trait Vertex2d: Clone + Copy + Sized {
 
 impl Vertex2d for Vec2 {
     #[inline(always)]
-    #[must_use]
     fn x(self) -> Float {
         self.x as Float
     }
 
     #[inline(always)]
-    #[must_use]
     fn y(self) -> Float {
         self.y as Float
     }
 }
 impl Vertex2d for DVec2 {
     #[inline(always)]
-    #[must_use]
     fn x(self) -> Float {
         self.x as Float
     }
 
     #[inline(always)]
-    #[must_use]
     fn y(self) -> Float {
         self.y as Float
     }
@@ -47,38 +43,32 @@ pub trait Vertex3d:
 }
 impl Vertex3d for Vec3 {
     #[inline(always)]
-    #[must_use]
     fn normalize(self) -> Self {
         self.normalize()
     }
 
     #[inline(always)]
-    #[must_use]
     fn cross(self, rhs: Self) -> Self {
         self.cross(rhs)
     }
 
     #[inline(always)]
-    #[must_use]
     fn dot(self, rhs: Self) -> Float {
         self.dot(rhs) as Float
     }
 }
 impl Vertex3d for DVec3 {
     #[inline(always)]
-    #[must_use]
     fn normalize(self) -> Self {
         self.normalize()
     }
 
     #[inline(always)]
-    #[must_use]
     fn cross(self, rhs: Self) -> Self {
         self.cross(rhs)
     }
 
     #[inline(always)]
-    #[must_use]
     fn dot(self, rhs: Self) -> Float {
         self.dot(rhs) as Float
     }


### PR DESCRIPTION
This causes the following warning:

> warning: `#[must_use]` attribute cannot be used on trait methods in impl blocks
  --> src/types/vertex.rs:21:5
   |
21 |     #[must_use]
   |     ^^^^^^^^^^^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = help: `#[must_use]` can be applied to data types, functions, unions, required trait methods, provided trait methods, inherent methods, foreign functions, and traits

and thus was removed