### PR TITLE
chore: update dependencies and make examples independent of glam version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ readme = "README.md"
 exclude = ["assets/", "docs/assets"]
 
 [dependencies]
-glam = { version = ">=0.21, <=0.29" }
-hashbrown = "0.14.5"
+glam = { version = ">=0.21, <=0.30" }
+hashbrown = "0.16.0"
 arrayvec = "0.7.4"
-thiserror = "1.0.63"
+thiserror = "2.0.17"
 
 tracing = { version = "0.1.40", optional = true }
 rayon = { version = "1.10.0", optional = true }

--- a/examples/src/debugger.rs
+++ b/examples/src/debugger.rs
@@ -15,12 +15,12 @@ use bevy::{
     hierarchy::DespawnRecursiveExt,
     input::{common_conditions::input_just_pressed, keyboard::KeyCode, ButtonInput},
     log::info,
+    math::{Vec2, Vec3},
     pbr::{MaterialPlugin, StandardMaterial},
     prelude::{default, AlphaMode, Component, Event, Resource},
     utils::HashSet,
 };
 use bevy_mod_billboard::plugin::BillboardPlugin;
-use ghx_constrained_delaunay::glam::{Vec2, Vec3};
 use ghx_constrained_delaunay::{
     debug::{DebugContext, DebugSnapshot},
     types::{Edge, TriangleId},
@@ -324,7 +324,7 @@ pub fn update_triangles_debug_view(
         _ => (),
     }
 
-    // Spawn label entites if enabled
+    // Spawn label entities if enabled
     match view_config.label_mode {
         LabelMode::All => {
             for (triangle_id, triangle_data) in snapshot.triangles.buffer().iter().enumerate() {

--- a/examples/src/debugger/gizmos.rs
+++ b/examples/src/debugger/gizmos.rs
@@ -1,14 +1,14 @@
 use bevy::{
-    color::{palettes::css::RED, Color},
+    color::{Color, palettes::css::RED},
     ecs::system::Res,
     gizmos::gizmos::Gizmos,
-    math::{Dir3, Vec3},
+    math::{Dir3, Quat, Vec3},
 };
 use ghx_constrained_delaunay::{
     debug::EventInfo,
     types::{opposite_vertex_index_from_edge, TriangleData, TriangleId},
 };
-use ghx_constrained_delaunay::{glam::Quat, infinite::collect_infinite_triangle_vertices};
+use ghx_constrained_delaunay::{infinite::collect_infinite_triangle_vertices};
 
 use crate::{
     infinite::{

--- a/examples/src/debugger/label.rs
+++ b/examples/src/debugger/label.rs
@@ -1,12 +1,13 @@
 use bevy::{
     ecs::system::Commands,
     log::error,
+    math::Vec3,
     prelude::default,
     text::{Text, TextSection, TextStyle},
     transform::components::Transform,
 };
 use bevy_mod_billboard::BillboardTextBundle;
-use ghx_constrained_delaunay::{glam::Vec3, infinite::collect_infinite_triangle_vertices};
+use ghx_constrained_delaunay::{infinite::collect_infinite_triangle_vertices};
 use ghx_constrained_delaunay::{
     infinite::infinite_vertex_local_quad_index,
     types::{opposite_vertex_index_from_edge, TriangleData, TriangleId, VERT_1, VERT_2},


### PR DESCRIPTION
Its not exactly pretty, but this will allow using a different version of `glam` than for example `bevy`.

I've also update all other direct dependencies in the process.