### PR TITLE
fix: CDT insertion for near-colinear constrained edges

### DIFF
--- a/src/constrained_triangulation.rs
+++ b/src/constrained_triangulation.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use hashbrown::HashSet;
+use hashbrown::{HashMap, HashSet};
 
 use crate::infinite::{
     collect_infinite_quad_vertices, edge_from_semi_infinite_edge, infinite_vertex_local_quad_index,
@@ -246,6 +246,48 @@ fn cdt_filter_triangles(
     indices
 }
 
+fn rebuild_vertex_to_triangle(triangles: &Triangles, vertex_to_triangle: &mut [TriangleId]) {
+    for (triangle_id, triangle) in triangles.buffer().iter().enumerate() {
+        for vertex in triangle.verts {
+            if is_finite(vertex) {
+                vertex_to_triangle[vertex as usize] = triangle_id as TriangleId;
+            }
+        }
+    }
+}
+
+fn rebuild_triangle_neighbors(triangles: &mut Triangles) {
+    let mut edge_to_triangle = HashMap::with_capacity(triangles.count() * 3);
+    let mut neighbor_pairs = Vec::new();
+
+    for triangle in triangles.buffer.iter_mut() {
+        triangle.neighbors = [Neighbor::NONE; 3];
+    }
+
+    for (triangle_id, triangle) in triangles.buffer().iter().enumerate() {
+        for (edge_index, edge) in triangle.edges().into_iter().enumerate() {
+            let edge_key = if edge.from < edge.to {
+                (edge.from, edge.to)
+            } else {
+                (edge.to, edge.from)
+            };
+
+            if let Some((other_triangle_id, other_edge_index)) =
+                edge_to_triangle.insert(edge_key, (triangle_id, edge_index))
+            {
+                neighbor_pairs.push((triangle_id, edge_index, other_triangle_id, other_edge_index));
+            }
+        }
+    }
+
+    for (triangle_id, edge_index, other_triangle_id, other_edge_index) in neighbor_pairs {
+        triangles.buffer[triangle_id].neighbors[edge_index] =
+            Neighbor::new(other_triangle_id as TriangleId);
+        triangles.buffer[other_triangle_id].neighbors[other_edge_index] =
+            Neighbor::new(triangle_id as TriangleId);
+    }
+}
+
 fn apply_constraints(
     vertices: &[Vertex],
     triangles: &mut Triangles,
@@ -277,6 +319,9 @@ fn apply_constraints(
     let mut new_diagonals_created = VecDeque::new();
     // Shared alloc for `restore_delaunay_triangulation_constrained`
     let mut swaps_history = HashSet::new();
+
+    rebuild_triangle_neighbors(triangles);
+    rebuild_vertex_to_triangle(triangles, &mut vertex_to_triangle);
 
     for (_edge_index, constrained_edge) in constrained_edges.iter().enumerate() {
         #[cfg(feature = "debug_context")]
@@ -439,8 +484,8 @@ fn loop_around_vertex_and_search_intersection(
             #[cfg(feature = "debug_context")]
             debug_context,
         );
+        let neighbor_triangle = triangle.neighbor(edge_index);
         if intersection == EdgesIntersectionResult::Crossing {
-            let neighbor_triangle = triangle.neighbor(edge_index);
             if neighbor_triangle.exists() {
                 return Ok(EdgeFirstIntersection::Intersection(EdgeData {
                     from_triangle_id: triangle_id,
@@ -454,6 +499,19 @@ fn loop_around_vertex_and_search_intersection(
                     debug_context,
                 ));
             }
+        }
+
+        if neighbor_triangle.exists()
+            && triangles
+                .get(neighbor_triangle.id)
+                .verts
+                .contains(&constrained_edge.to)
+        {
+            return Ok(EdgeFirstIntersection::Intersection(EdgeData {
+                from_triangle_id: triangle_id,
+                to_triangle_id: neighbor_triangle.id,
+                edge,
+            }));
         }
 
         let neighbor = triangle.neighbor(next_edge_index(vert_index));
@@ -831,6 +889,20 @@ fn quad_diagonals_intersection(vertices: &[Vertex], quad: &Quad) -> EdgesInterse
     }
 }
 
+fn quad_has_constrained_diagonal(
+    vertices: &[Vertex],
+    quad: &Quad,
+    constrained_edge_vertices: &EdgeVertices,
+) -> bool {
+    if !is_finite(quad.v3()) || !is_finite(quad.v4()) {
+        return false;
+    }
+
+    let diagonal = (vertices[quad.v3() as usize], vertices[quad.v4() as usize]);
+    (diagonal.0 == constrained_edge_vertices.0 && diagonal.1 == constrained_edge_vertices.1)
+        || (diagonal.0 == constrained_edge_vertices.1 && diagonal.1 == constrained_edge_vertices.0)
+}
+
 fn remove_crossed_edges(
     triangles: &mut Triangles,
     vertices: &[Vertex],
@@ -857,11 +929,15 @@ fn remove_crossed_edges(
         let quad = intersection.to_quad(triangles);
         // If the quad is not convex (diagonals do not cross) or if an edge tip lie on the other edge,
         // we skip this edge and put it on the stack to re-process it later
-        if quad_diagonals_intersection(vertices, &quad) != EdgesIntersectionResult::Crossing {
+        let should_swap = quad_diagonals_intersection(vertices, &quad)
+            == EdgesIntersectionResult::Crossing
+            || quad_has_constrained_diagonal(vertices, &quad, constrained_edge_vertices);
+
+        if !should_swap {
             intersections.push_back(intersection);
             non_convex_counter += 1;
         }
-        // Swap the diagonal of this strictly convex quadrilateral if the two diagonals cross normaly
+        // Swap the diagonal if the two diagonals cross normally, or if the constrained edge is the alternate diagonal of a near-degenerate quad.
         else {
             non_convex_counter = 0;
             swap_quad_diagonal(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,4 +195,45 @@ mod tests {
             triangulation.triangles
         );
     }
+
+    #[test]
+    fn constrained_delaunay_near_colinear_edges() {
+        let vertices = vec![
+            Vertex::new(-0.0782132158260142, 0.0),
+            Vertex::new(-0.04346227742441594, 0.10349781560157462),
+            Vertex::new(0.0388118494777121, 0.2521774205252516),
+            Vertex::new(0.10736492278480181, 0.3364695064078743),
+            Vertex::new(-0.03490517918394376, 0.12472698060408025),
+            Vertex::new(0.021085609120375826, 0.22442779757191253),
+            Vertex::new(0.12874905992983615, 0.3600245316864931),
+            Vertex::new(0.1901120866083647, 0.4212073366884178),
+            Vertex::new(-0.1901120866083661, 0.0),
+            Vertex::new(-0.1901120866083661, 2.0),
+            Vertex::new(0.19011208660836504, 0.0),
+            Vertex::new(0.19011208660836504, 2.0),
+        ];
+
+        let edges = vec![
+            Edge::new(11, 7),
+            Edge::new(8, 9),
+            Edge::new(7, 10),
+            Edge::new(9, 11),
+            Edge::new(4, 1),
+            Edge::new(1, 0),
+            Edge::new(0, 8),
+            Edge::new(6, 3),
+            Edge::new(2, 5),
+            Edge::new(3, 2),
+            Edge::new(5, 4),
+            Edge::new(6, 7),
+            Edge::new(10, 0),
+        ];
+
+        constrained_triangulation_from_2d_vertices(
+            &vertices,
+            &edges,
+            ConstrainedTriangulationConfiguration::default(),
+        )
+        .expect("Triangulation should succeed for near-colinear constrained edges");
+    }
 }


### PR DESCRIPTION
## Summary

Fix for the CDT failure on near-colinear constrained edges, see Henauxg/ghx_constrained_delaunay#6.

The failing case involved a constrained edge that was effectively the alternate diagonal of an adjacent, near-degenerate quad. Because the existing constrained-edge insertion path only followed strictly crossing edges, it could fail to find the first intersected quad and abort with an internal cycle/search error.

To fix, we rebuild triangle neighbor links once before applying constraints, ensuring the constraint walk starts from consistent adjacency data. We rebuild `vertex_to_triangle` after that consistency pass. We allow the constraint walk to detect when the target vertex is in the neighboring triangle across the candidate edge. We also allow `remove_crossed_edges` to swap a near-degenerate quad when the constrained edge is the quad’s alternate diagonal, even if the diagonals do not strictly cross.

I added a regression test covering the near-colinear polygon that previously failed.

The consistency rebuild is a single linear pre-pass over the triangulation before constraints are applied. It does not run once per constrained edge.

So this adds an `O(T)` pass, where `T` is the number of triangles, but does not change the overall expected asymptotic shape of CDT construction.

## Validation

- `cargo test constrained_delaunay_near_colinear_edges -- --nocapture`